### PR TITLE
Do not persist credentials during checkout

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -10,6 +10,8 @@ jobs:
       release-version: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -1,0 +1,16 @@
+name: On Tag
+on:
+  push:
+    tags:
+      - genopace-test-artefact-*
+
+permissions:
+  contents: read
+
+jobs:
+  on-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Received tag event for ${{ git.ref_name }}!"
+
+


### PR DESCRIPTION
GH customer support suspects that the maven release tagging does not use the provided PAT but the workflow token persisted by the checkout action.